### PR TITLE
Refactor/config implements new %date% template, removes commit title config in favor of commit format config

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,8 @@ Prerequisites:
 
 If xgs can't find its config file (`xgs.json`) it will fallback to its default config:
 
-```json
+```jsonc
 {
-  // will be inserted into the %title% placeholder in the commit_format string
-  "commit_title": "backup",
-
   // specifies the date format which the date will be formatted as
   //
   //  - 2006 for the year, 06 would only be the last two integer
@@ -106,9 +103,8 @@ If xgs can't find its config file (`xgs.json`) it will fallback to its default c
   "commit_date": "2006-01-02 15:04:05",
 
   // specifies the format of the commit, currently supports:
-  // - commit_title: %title%
   // - commit_date: %date%
-  "commit_format": "%title% %date%",
+  "commit_format": "backup: %date%",
 
   // List filenames affected by the commit in the commit body
   // together with the type of change which happend to the file:

--- a/README.md
+++ b/README.md
@@ -2,14 +2,7 @@
 
 Backup your repository at configured intervals
 
-
-
-
 https://user-images.githubusercontent.com/47723417/213995030-a72ab64f-3e64-403e-bda7-57279b37780d.mp4
-
-
-
-
 
 ## Why use xgs
 
@@ -93,10 +86,10 @@ Prerequisites:
 
 If xgs can't find its config file (`xgs.json`) it will fallback to its default config:
 
-```jsonc
+```json
 {
-  // will be inserted before the local date string in the commit title
-  "auto_commit_prefix": "backup: ",
+  // will be inserted into the %title% placeholder in the commit_format string
+  "commit_title": "backup",
 
   // specifies the date format which the date will be formatted as
   //
@@ -110,7 +103,12 @@ If xgs can't find its config file (`xgs.json`) it will fallback to its default c
   // time formatting in go is weird, see docs:
   //
   // https://www.digitalocean.com/community/tutorials/how-to-use-dates-and-times-in-go
-  "commit_title_date_format": "2006-01-02 15:04:05",
+  "commit_date": "2006-01-02 15:04:05",
+
+  // specifies the format of the commit, currently supports:
+  // - commit_title: %title%
+  // - commit_date: %date%
+  "commit_format": "%title% %date%",
 
   // List filenames affected by the commit in the commit body
   // together with the type of change which happend to the file:

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 	if devMode {
 		conf.DebugMode = true
 		DebugLog(conf, "Dev mode enabled, automatically enabled debug mode, adding, committing and pushing will be disabled.")
-		generateCommitContent(conf)
+		log.Println(generateCommitContent(conf))
 		os.Exit(0)
 	}
 

--- a/sync.go
+++ b/sync.go
@@ -115,8 +115,8 @@ func GitCommit(conf Config) {
 // - the affected files if AddAffectedFiles is true
 func generateCommitContent(conf Config) []string {
 	DebugLog(conf, "generating commit content...")
-	commitTime := time.Now().Format(conf.CommitTitleDateFormat)
-	commitContent := conf.AutoCommitPrefix + commitTime
+	commitTime := time.Now().Format(conf.CommitDate)
+	commitContent := strings.ReplaceAll(conf.CommitFormat, "%date%", commitTime)
 	commit := make([]string, 0)
 	if conf.AddAffectedFiles {
 		affectedFiles := gitAffectedFiles(conf)

--- a/util.go
+++ b/util.go
@@ -10,12 +10,10 @@ import (
 )
 
 type Config struct {
-	// will be inserted before the local date string in the commit title, default: "backup: "
-	AutoCommitPrefix string `json:"auto_commit_prefix"`
-
-	// TODO: implement
-	//
-	// CommitTitle string `json:"custom_commit_title"`
+	// specifies the format of the commit message, default: "backup: %date%"
+	// currently supportes:
+	// - %date%: the date of the commit, formatted as specified in Commit_date
+	CommitFormat string `json:"commit_format"`
 
 	// specifies the date format which the date will be formatted as, default: "2006-01-02 15:04:05"
 	//
@@ -29,7 +27,7 @@ type Config struct {
 	// time formatting in go is weird, see docs:
 	//
 	// https://www.digitalocean.com/community/tutorials/how-to-use-dates-and-times-in-go
-	CommitTitleDateFormat string `json:"commit_title_date_format"`
+	CommitDate string `json:"commit_date"`
 
 	// List filenames affected by the commit in the commit body, default: true
 	AddAffectedFiles bool `json:"add_affected_files"`
@@ -54,28 +52,16 @@ type Config struct {
 // - On Plan 9, it returns $home/lib
 //
 // config file location depends on os.UserConfigDir()
-//
-// if config is not found the fallback config is:
-//
-//		Config{
-//	     AutoCommitPrefix:      "backup: ",
-//	     BackupInterval:        300,
-//	     CommitCommand:         "git commit -m",
-//	     AddAffectedFiles:      true,
-//	     CommitTitleDateFormat: "2006-01-02 15:04:05",
-//			DebugMode:             false,
-//			PullOnStart:           true,
-//		}
 func getConfig() Config {
 	// all occuring errors are logged, but not treated like panics, due to the fact that a fallback config is provided
 	fallbackConf := Config{
-		AutoCommitPrefix:      "backup: ",
-		BackupInterval:        300,
-		CommitCommand:         "git commit -m",
-		AddAffectedFiles:      true,
-		CommitTitleDateFormat: "2006-01-02 15:04:05",
-		DebugMode:             false,
-		PullOnStart:           true,
+		CommitFormat:     "backup: %date%",
+		BackupInterval:   300,
+		CommitCommand:    "git commit -m",
+		AddAffectedFiles: true,
+		CommitDate:       "2006-01-02 15:04:05",
+		DebugMode:        false,
+		PullOnStart:      true,
 	}
 
 	confDir, _ := os.UserConfigDir()


### PR DESCRIPTION
- renamed AutoCommitTitle to CommitFormat (`auto_commit_title` -> `commit_format`)
- renamed CommitTitleDateFormat to CommitDate (`commit_title_date_format` -> `commit_date`)
- commit format contains text and templates (named between `%`):
  ```json
  {
    "commit_date": "2006-01-02 15:04:05",
    "commit_format": "commit title: %date%"
  }
  ```
  - The `%date%` placeholder will be replaced by the value in the renamed `commit_date` config value
  - currently, the `%date%` placeholder is the only accepted placeholder - it gets replaced while generating the commit title using the `strings.ReplaceAll` method, future plans include the support for all configuration options as placeholders or maybe a custom object of key value pairs in the config which represents placeholders

- updated documentation for the config in code comments and the README